### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 ## Dropbox Connect
 
-Plugin for [fman.io](https://fman.io) that allows you to perform actions on your Dropbox files. This plugin also contains the Dropbox file system for interacting with your Dropbox accounts just like you local disk. Currently, only browsing the file system is implemented. The browsing shows the file/directory names, size of the files only, and an 🔄 if it is synced to your file system. I'm working on copy, move, delete, and getting the public link for files in the Dropbox filesystem.
+Plugin for [fman.io](https://fman.io) that allows you to perform actions on your Dropbox files. This plugin also contains the Dropbox file system for interacting with your Dropbox accounts just like your local disk. Currently, only browsing the file system is implemented. The browsing shows the file/directory names, size of the files only, and an 🔄 if it is synced to your file system. I'm working on copy, move, delete, and getting the public link for files in the Dropbox filesystem.
 
 You can install this plugin by pressing `<shift+cmd+p>` to open the command pallet. Then type `install plugin`. Look for the `DropboxConnect` plugin and select it.
 
 After restarting **fman**, you will have the ability to get a public link to a file in your Dropbox personal or business account.
+
+#### Setup
+
+Once the plugin is installed, set the Dropbox directories by having the cursor on the personal Dropbox directory and run the command `set personal db` in the command prompt. Do the same with the business directory.
+
+Next, log into the [App Console](https://www.dropbox.com/developers/apps) of your Dropbox account in a web browser. Select the 'Create app' link on the 'App Console' page. Fill out the form with the following selections: 'Dropbox API', and 'Full Dropbox'. The name can be anything you want. I used "fmanConnectP". Then select 'Personal', and 'Create app'.
+
+Dropbox will then have you on the new apps page. Scroll down to 'Generate access token' and select 'Generate'. Copy the alphanumeric token given. In fman, run the `set personal secret` and give it this token. Do the same for the business account if you have one.
+
+Now you can select any file in a Dropbox directry and use the `get Dropbox public link` command or `<shift>+<ctrl>+d` hotkey. The public link will be copied to the clipboard.
 
 ### Usage
 
@@ -53,16 +63,6 @@ This command will open the current panel in the Dropbox file system. Currently, 
 `DropboxConnect.json`
 
 This file contains the directory location and the secrets for the personal and business Dropbox accounts.
-
-#### Suggested Usage
-
-Once the plugin is installed, set the Dropbox directories by having the cursor on the personal Dropbox directory and run the command `set personal db` in the command prompt. Do the same with the business directory.
-
-Next, log into your Dropbox account in a web browser, go to the settings page, scroll to the bottom and select 'Developers'. On the Developer page, select the 'My Apps' link. Select the 'Create app' link on the 'App Console' page. Fill out the form with the following selections: 'Dropbox API', and 'Full Dropbox'. The name can be anything you want. I used "fmanConnectP". Then select 'Personal', and 'Create app'.
-
-Dropbox will then have you on the new apps page. Scroll down to 'Generate access token' and select 'Generate'. Copy the alphanumeric token given. In fman, run the `set personal secret` and give it this token. Do the same for the business account if you have one.
-
-Now you can select any file in a Dropbox directry and use the `get Dropbox public link` command or `<shift>+<ctrl>+d` hotkey. The public link will be copied to the clipboard.
 
 ### Features
 


### PR DESCRIPTION
The README described how one could set up the Dropbox app required for the integration. The links it mentioned were very difficult to discover because (for me) they are hidden in submenus which the README didn't mention. This PR uses a link instead that should work for all users.